### PR TITLE
Add warning when IntersectionObserver API is not available

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -217,3 +217,52 @@ test('It should not warn if Vue.config.silent is set to false', async () => {
 
   global.console.warn.mockReset()
 })
+
+test('It should warn if IntersectionObserver is not available', async () => {
+  global.IntersectionObserver = undefined
+  global.console.warn = jest.fn()
+  const vm = new Vue({
+    template: `<intersect><div></div><div></div></intersect>`,
+    components: {Intersect}
+  }).$mount()
+
+  await vm.$nextTick()
+
+  expect(global.console.warn).toHaveBeenCalled()
+  expect(global.console.warn).toHaveBeenCalledWith('[vue-intersect] IntersectionObserver API is not available in your browser. Please install this polyfill: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill')
+  global.IntersectionObserver = IntersectionObserver
+})
+
+test('It should return in mounted function if IntersectionObserver is not available', () => {
+  global.IntersectionObserver = undefined
+  const vm = new Vue({
+    template: `<intersect><div></div><div></div></intersect>`,
+    components: {Intersect}
+  }).$mount()
+
+  vm.$nextTick = jest.fn()
+  vm.observer = {
+    observe: jest.fn()
+  }
+
+  expect(vm.$nextTick).not.toHaveBeenCalled()
+  expect(vm.observer.observe).not.toHaveBeenCalled()
+  global.IntersectionObserver = IntersectionObserver
+})
+
+test('It should return in destroyed function if IntersectionObserver is not available', () => {
+  global.IntersectionObserver = undefined
+  const vm = new Vue({
+    template: `<intersect><div></div><div></div></intersect>`,
+    components: {Intersect}
+  }).$mount()
+
+  vm.observer = {
+    observe: jest.fn()
+  }
+
+  vm.$destroy()
+
+  expect(vm.observer.observe).not.toHaveBeenCalled()
+  global.IntersectionObserver = IntersectionObserver
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,7 @@ export default {
       type: Array,
       required: false,
       default: function _default() {
-        return [0.2];
+        return [0, 0.2];
       }
     },
     root: {
@@ -35,6 +35,12 @@ export default {
   created: function created() {
     var _this = this;
 
+    this.isIntersectionObserver = typeof IntersectionObserver !== 'undefined';
+    if (!this.isIntersectionObserver) {
+      console.warn('[vue-intersect] IntersectionObserver API is not available in your browser. Please install this polyfill: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill');
+      return;
+    }
+
     this.observer = new IntersectionObserver(function (entries) {
       if (!entries[0].isIntersecting) {
         _this.$emit('leave', [entries[0]]);
@@ -52,6 +58,7 @@ export default {
   mounted: function mounted() {
     var _this2 = this;
 
+    if (!this.isIntersectionObserver) return;
     this.$nextTick(function () {
       if (_this2.$slots.default && _this2.$slots.default.length > 1) {
         warn('[VueIntersect] You may only wrap one element in a <intersect> component.');
@@ -64,6 +71,7 @@ export default {
     });
   },
   destroyed: function destroyed() {
+    if (!this.isIntersectionObserver) return;
     this.observer.disconnect();
   },
   render: function render() {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,12 @@ export default {
     }
   },
   created () {
+    this.isIntersectionObserver = typeof IntersectionObserver !== 'undefined'
+    if (!this.isIntersectionObserver) {
+      console.warn('[vue-intersect] IntersectionObserver API is not available in your browser. Please install this polyfill: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill')
+      return
+    }
+
     this.observer = new IntersectionObserver((entries) => {
       if (!entries[0].isIntersecting) {
         this.$emit('leave', [entries[0]])
@@ -42,6 +48,7 @@ export default {
     })
   },
   mounted () {
+    if (!this.isIntersectionObserver) return
     this.$nextTick(() => {
       if (this.$slots.default && this.$slots.default.length > 1) {
         warn('[VueIntersect] You may only wrap one element in a <intersect> component.')
@@ -54,6 +61,7 @@ export default {
     })
   },
   destroyed () {
+    if (!this.isIntersectionObserver) return
     this.observer.disconnect()
   },
   render () {


### PR DESCRIPTION
## Description
- [x] Add warning when no IntersectionObserver API
- [x] Do nothing in `created`, `mounted` and `destroyed`
- [x] Add unit test