### PR TITLE
Removed unnecessary array wrapping the entry argument of events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,12 +29,12 @@ export default {
   created () {
     this.observer = new IntersectionObserver((entries) => {
       if (!entries[0].isIntersecting) {
-        this.$emit('leave', [entries[0]])
+        this.$emit('leave', entries[0])
       } else {
-        this.$emit('enter', [entries[0]])
+        this.$emit('enter', entries[0])
       }
 
-      this.$emit('change', [entries[0]])
+      this.$emit('change', entries[0])
     }, {
       threshold: this.threshold,
       root: this.root,


### PR DESCRIPTION
Vue's `$emit` method is defined as `vm.$emit( eventName, […args] )` which means that every argument of a custom event should be a separate argument of `$emit`.

The extra array is unnecessary and forces me to unpack the first item to access the entry:

```html
<template>
  <!-- snip -->
    <intersect @enter="intersecting">
      <div>Hello world</div>
    </intersect>
  <!-- snip -->
</template>

<script>
export default {
  // [snip]
  methods: {
    intersecting(extraArray) {
      const entry = extraArray[0]
      // ...
    }

    // alternative
    intersecting([entry]) {
      // ...
    }
  }
}
</script>