### PR TITLE
add destroy event and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This means that it's basically a "decorator". A component which does not output 
 | **change** | [*IntersectionObserverEntry*](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | Event fired on any inte.                 |
 | **enter**  | [*IntersectionObserverEntry*](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | Event fired when the element is intersected (visible on the screen) |
 | **leave**  | [*IntersectionObserverEntry*](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | Event fired when the element is *not* intersected (not visible on the screen) |
+| **destroyed** | None | Fired when the underlying element is destroyed |
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export default {
     })
   },
   destroyed () {
+    this.$emit('destroyed');
     this.observer.disconnect()
   },
   render () {


### PR DESCRIPTION
I ended up requiring a destroy event to tell when the underlying component the <intersect> observer was observing had disappeared because no "leave" event was fired in that scenario.

Example usage scenario:
```html
<div v-for="child in menuNodes" :key="child.key">
    <intersect
        @leave="hide(child.key, $event)"
        @enter="show(child.key, $event)"
        @destroyed="hide(child.key, $event)">
        <render-node :node="child" />
    </intersect>
</div>
```

Here I was wrapping each element from a list of slot contents with your component to be able to tell whether or not they had passed out of view, but the items on menuNodes list (of VNodes) are themselves dynamic meaning the list can change from the outside, which can cause the intersect component and associated contents to disappear without firing a "leave" event.

Admittedly you can fix it this way too:
```js
import Intersect from "vue-intersect";

const FixedIntersect = {
    ...Intersect,
    destroyed() {
        this.$emit("destroyed");
        Intersect.destroyed.call(this);
    }
}
```
